### PR TITLE
Fix project graph

### DIFF
--- a/components/graph.py
+++ b/components/graph.py
@@ -344,6 +344,7 @@ def is_unassigned():
   )
 
 def flipped(edges):
+  """Return the reverse graph, with all edges flipped."""
   for (u, v, *rest) in edges:
     yield (v, u, *rest)
 

--- a/components/graph.py
+++ b/components/graph.py
@@ -250,35 +250,6 @@ def node_adjacent(node, edges, direction):
         if   node == u: yield v
         elif node == v: yield u
 
-def traverse(node, edges, direction, ancestors=None, seen=None):
-  """Yield nodes from the subgraph rooted at `node`.
-
-  @node      - the root node
-  @edges     - the edge set to follow
-  @direction - incoming, outoging, or both.
-  @ancestors - the path up to the root.
-  @seen      - a.k.a. the "visited" set.
-
-  This is the general traversal, special cases of which appear below.
-  """
-  if node in ancestors:
-    if direction == "all":
-      return
-    else:
-      print("Graph contains a cycle", file=sys.stderr)
-      exit(1)
-
-  if node not in seen:
-    yield node
-    for adj in node_adjacent(node, edges, direction):
-      yield from traverse(
-        adj,
-        edges,
-        direction,
-        ancestors | {node},
-        seen    | {node}
-      )
-
 def has_adjacent(node, edges, direction):
   """True if a node has edges in the given direction"""
   return len(list(node_adjacent(node, edges, direction))) > 0

--- a/components/graph.py
+++ b/components/graph.py
@@ -141,22 +141,24 @@ def subtask_groups(node):
 
   return ret
 
-def project_subgraph(node, groups):
-  """Compute subgraph for a given project node.
+def subtask_edges(node, groups, projects):
+  """Generate the edges for a set of subtask groups.
 
   Groups are parallel w/r/t each other. Each group is a linear chain
-  of tasks.
-  """
+  of tasks. Tasks groups are assumed to be in reverse order from the
+  on-disk format.
 
+  """
   for group in groups:
     match group:
       case [prev, *rest] as subtasks:
-        yield (node, prev, "implicit")
+        yield (node, prev, "subtask")
         for next in rest:
-          yield (prev, next, "implicit")
+          if prev in projects:
+            yield (f"{prev}-start", f"{node}-start", "sibling")
+          yield (prev, next, "sibling")
           prev = next
-      case _:
-        raise ValueError("Empty group")
+        yield (prev, f"{node}-start", "leaf")
 
 def get_subtasks(node):
   """Get all the subtasks of a project.
@@ -165,21 +167,101 @@ def get_subtasks(node):
   """
   return filter(bool, read_subtasks(node))
 
+def is_start_node(node):
+  """True if a node id identifies a virtual start node."""
+  return node.endswith("-start")
+
+def project_subgraph(projects):
+  """Construct the intermediate project task graph.
+
+  This is the union of all subtask edges and all the explicit eges,
+  with project-level dependencies blocking the project
+  start node.
+  """
+
+  for (node, groups) in projects.items():
+    yield from subtask_edges(node, groups, projects)
+
+  for (u, v) in read_edges("dependencies"):
+    if u in projects:
+      yield (f"{u}-start", v, "leaf")
+    else:
+      yield (u, v)
+
+def merge_start_nodes_iter(edges):
+  """Remove one layer of virtual nodes, preserving connectivity.
+  """
+
+  edges = set(edges)
+  outgoing = adjacency_list(edges)
+  incoming = adjacency_list(flipped(edges))
+  empty = set()
+
+  for (u, v, *rest) in edges:
+    us = incoming.get(u, empty) if is_start_node(u) else {u}
+    vs = outgoing.get(v, empty) if is_start_node(v) else {v}
+    for u in us:
+      for v in vs:
+        yield (u, v, *rest)
+
+def merge_start_nodes(edges):
+  """Recursively remove start nodes from the graph.
+
+  We need to the full edge list in order to do this correctly, so it
+  has to be a distinct pass.
+
+  If any start nodes remain in the output, we recursively perform
+  another pass.
+  """
+
+  iter = False
+  ret = set()
+
+  for edge in merge_start_nodes_iter(edges):
+    (u, v, *rest) = edge
+    if is_start_node(u) or is_start_node(v):
+      iter = True
+    ret.add(edge)
+
+  if iter:
+    return merge_start_nodes(ret)
+  else:
+    return ret
+
 def dependencies():
   """A generator which yields all dependency edges.
 
   We have to special-case "Project" nodes to get the correct
   graph.
 
-  Confusion arises from the tension between "outline format" and the
-  naive interpretation of a tree as a DAG. Outline format implies:
+  Complexity arises from the "outline format" of the substasks file
+  and the naive interpretation of a tree as an explicit DAG. Outline
+  format implies:
 
-   1. Reverse ordering, with the first subtask considered a leaf.
-   2. Implicit chaining, with a happens-before between each successive sibling.
-   3. Project-level dependencies implicitly project from the first child.
+   1. Reverse ordering, with the first subtask in a group considered a leaf.
+   2. Implicit chaining, with each successive sibling depending on the previous.
+   3. Project-level dependencies implicitly block project leaves.
 
-  In addition, we want to allow arbitrary parallelism within the
-  project, where appropriate.
+  This requires a multi-pass approach. The first pass constructs an
+  incomplete project dag from the subtasks file for each
+  project. During this pass, we in insert virtual start nodes which
+  implicitly block the leaves of each project.
+
+  We then process the explicit edges of the graph, adjusting any
+  project-level dependencies to block to the virtual start node,
+  rather than the project node itself.
+
+  Finally, the virtual nodes are removed by merging edges with their
+  neighbors. We could skip this step, but this breaks the invariant
+  that node IDs always refer to a valid path in the DB, resulting in
+  numerous downstream issues.
+
+  Earlier approaches were simpler, but incorrectly treated
+  project-level dependencies as leaves in some cases. The intention is
+  that as a task expands into a project, any explicit dependencies it
+  might have continue to depend on the task as a whole, including its
+  transitive dependencies.
+
   """
 
   # Find all the project nodes
@@ -189,25 +271,7 @@ def dependencies():
     if has("subtasks", node)
   }
 
-  # Emit all the project subtask edges.
-  for (node, groups) in projects.items():
-    yield from project_subgraph(node, groups)
-
-  # Emit all the explicit edges in the graph, special-casing direct
-  # dependencies from project nodes.
-  #
-  # Project-level dependencies implicitly block all the leaves of a
-  # project. Direct dependencies between a project's subtasks may also
-  # exist.
-  #
-  # The leaves of a project are just the last task in each subtask
-  # group.
-  for (u, v) in read_edges("dependencies"):
-    if u in projects and projects[u]:
-      for subtask in [g[-1] for g in projects[u]]:
-        yield (subtask, v, "implicit")
-    else:
-      yield (u, v)
+  yield from merge_start_nodes(project_subgraph(projects))
 
 def edge_list(edge_set, subtasks=True):
   """Get the set of edges for the given edge set.
@@ -673,5 +737,5 @@ if __name__ == "__main__":
     "touches":        touches,
     "contained":      contained,
     "summary":        summary,
-    "dangling":       dangling
+    "dangling":       dangling,
   }[sys.argv[1]](*sys.argv[2:])

--- a/components/graph.py
+++ b/components/graph.py
@@ -440,14 +440,19 @@ def datum_read(datum, id):
 def task_contents(id):
   return datum_read("contents", id)
 
-def task_gloss(id):
-  if has("contents", id):
-    return task_contents(id).split('\n')[0]
-  else:
-    if id in os.listdir(BUCKET_DIR):
-      return id
+def task_gloss(ref):
+  def gloss(id):
+    if has("contents", id):
+      return task_contents(id).split('\n')[0]
     else:
-      return "[no contents]"
+      if id in os.listdir(BUCKET_DIR):
+        return id
+      else:
+        return "[no contents]"
+
+  match ref.split("-start"):
+    case [id, '']: return gloss(id) + "::start"
+    case [id]:     return gloss(id)
 
 def task_state(id):
   return datum_read("state", id)

--- a/components/graph.py
+++ b/components/graph.py
@@ -347,69 +347,51 @@ def flipped(edges):
   for (u, v, *rest) in edges:
     yield (v, u, *rest)
 
-def adjacency_list(edges, direction):
+def adjacency_list(edges):
   """Build forward edge adjacency list."""
+  ret = {id: set() for id in nodes()}
+  for (u, v, *rest) in edges:
+    if u not in ret:
+      ret[u] = set()
+    ret[u].add(v)
+  return ret
+
+def reachability_set(edges, nodes, mem=None):
+  """Return the reachability set for the given node."""
+  adj = adjacency_list(edges)
+  mem = mem if mem is not None else {}
+  empty = set()
+
+  def rec(n):
+    if n not in mem:
+      mem[n] = {n}
+      for a in adj.get(n, empty):
+        mem[n] |= rec(a)
+    return mem[n]
+
+  return reduce(set.__ior__, (rec(n) for n in nodes))
+
+def reachable_from(edges, direction, *nodes):
+  """Keep nodes reachable via `edges` along `direction` from the given set of nodes."""
 
   match direction:
     case "outgoing": edges = edge_list(edges)
     case "incoming": edges = flipped(edge_list(edges))
     case invalid: raise ValueError(f"{invalid} is not one of incoming or outgoing")
 
-  ret = {id: set() for id in nodes()}
-  for (u, v, *rest) in edges:
-    try:
-      ret[u].add(v)
-    except KeyError:
-      debug(f"Dangling reference to node {u}")
-  return ret
-
-def reachable_from(edges, direction, *nodes):
-  """Keep nodes reachable via `edges` along `direction` from the given set of nodes."""
-
-  # Recursively-construct reachability map.
-  adj = adjacency_list(edges, direction)
-  mem = {}
-
-  def rec(n):
-    if n not in mem:
-      mem[n] = {n}
-      for a in adj[n]:
-        mem[n] |= rec(a)
-    return mem[n]
-
-  reachable = reduce(set.__ior__, (rec(n) for n in nodes))
+  reachable = reachability_set(edges, nodes)
   filter_nodes(lambda n: n in reachable)
-
-  # reachable =
-
-  # for n in nodes:
-
-  # ret = {}
-
-  # def rec(n):
-  #   if n in ret: return
-  #   else:
-  #     for node in adjacent(e
-
-  # edges = edge_list(edges)
-  # seen = set()
-  # return {node: rec(n) for node in nodes}
-
-  #   for subtask in traverse(node, edges, direction, set(), seen):
-  #     if subtask not in seen:
-  #       seen.add(subtask)
-  #       print(subtask)
-
 
 def reachable(edges, direction):
   """Expand the incoming node set to include nodes reachable from the input set."""
-  edges = edge_list(edges)
-  seen = set()
-  for node in read_ids():
-    for subtask in traverse(node, edges, direction, set(), seen):
-      if subtask not in seen:
-        seen.add(subtask)
-        print(subtask)
+  match direction:
+    case "outgoing": edges = edge_list(edges)
+    case "incoming": edges = flipped(edge_list(edges))
+    case invalid: raise ValueError(f"{invalid} is not one of incoming or outgoing")
+
+  nodes = set(read_ids())
+  for node in reachability_set(edges, nodes):
+    print(node)
 
 def dangling_contexts():
   """List nodes still linked to deleted nodes."""
@@ -479,7 +461,7 @@ def touches(*edge_sets):
     edge_sets = ('contexts', 'dependencies')
   nodes = set(read_ids())
   for edge_set in edge_sets:
-    for (u, v, *_) in read_edges(edge_set):
+    for (u, v, *_) in edge_list(edge_set):
       if edge_touches(u, v, nodes):
         print(f"{u} {v} {edge_set}")
 
@@ -489,7 +471,7 @@ def contained(*edge_sets):
     edge_sets = ('contexts', 'dependencies')
   nodes = set(read_ids())
   for edge_set in edge_sets:
-    for (u, v, *_) in read_edges(edge_set):
+    for (u, v, *_) in edge_list(edge_set):
       if edge_contained(u, v, nodes):
         print(f"{u} {v} {edge_set}")
 
@@ -568,13 +550,13 @@ def dot_node(id, node_labels={}, shape="box"):
   )
   return f"{dot_quote(id)} {formatted_attrs};"
 
-def dot_edge(u, v, style, color):
+def dot_edge(u, v, style, color, arrow="normal"):
   """Return a formatted edge in dot syntax.
 
   Context edges are dashed, dependency edges are solid.
   """
   return f"{dot_quote(u)} -> {dot_quote(v)}" \
-         f"[style={dot_quote(style)}, color={dot_quote(color)}];"
+         f"[style={dot_quote(style)}, color={dot_quote(color)}, arrowhead={arrow}];"
 
 def dot_edges(edges, nodes, color):
   """Format the given edge sets to stdout"""
@@ -583,18 +565,22 @@ def dot_edges(edges, nodes, color):
       case (u, v):
         if edge_contained(u, v, nodes):
           print(dot_edge(u, v, "solid", color))
-      case (u, v, "implicit"):
+      case (u, v, "subtask"):
         if edge_contained(u, v, nodes):
           print(dot_edge(u, v, "dashed", color))
+      case (u, v, "leaf"):
+        if edge_contained(u, v, nodes):
+          print(dot_edge(u, v, "dashed", color, "empty"))
+      case (u, v, "sibling"):
+        if edge_contained(u, v, nodes):
+          print(dot_edge(u, v, "dashed", color, "odot"))
 
 def dot(*selection):
   """Read nodes from stdin, write dot syntax to stdout."""
   selected = set(selection)
   nodes = set([])
   node_labels = {}
-
   buckets = set(os.listdir(BUCKET_DIR))
-
   projects = set()
 
   print( "digraph {")

--- a/gtd.sh
+++ b/gtd.sh
@@ -2269,7 +2269,7 @@ function capture {
     done
 
     local node="$(graph_node_create)"
-    echo "NEW" | graph_datum state write "${node}"
+    echo "NEW" | task_state write "${node}"
 
     # no need to call "end filter chain", as we consume all arguments.
     if test -z "$*"; then


### PR DESCRIPTION
This is an incremental fix to the project graph generation from subtasks files.

This is tricky because I have to handle both `subtasks `files and explicit edges. This is probably not the final version of the algorithm, but it's tricky to debug and write tests for without proper motivating examples, and I'm dogfooding. This change seems to fix a number of cases where nested projects were not being scheduled properly, leading to more leaf nodes than is actually desired.

The gist of this change has to do with how sibling edges are handled -- when a sibling is a sub-project, then the *entire* sub-project should be "patched in".

This change introduces a new framework for project graph generation, which is based on the idea of "virtual start nodes", which implicitly block the leaves of every project's subtasks. Direct project dependencies, and sibling edges, are re-directed to the start node. Then the start nodes are recursively merged into the final graph.