### PR TITLE
Remove graph/bucket_mode and graph/subtasks_mode setttings

### DIFF
--- a/components/graph.py
+++ b/components/graph.py
@@ -635,52 +635,12 @@ def dot(*selection):
       projects.add(node)
     nodes.add(node)
 
-  match subtasks_mode:
-    case "cluster":
-      for project in projects:
-        subtasks = set(get_subtasks(project))
-        subtasks.add(project)
-        nodes |= subtasks
-        dot_subgraph(task_gloss(project), subtasks, id=project)
-    case "label":
-      for project in projects:
-        subtasks = set(get_subtasks(project))
-        subtasks.add(project)
-        nodes |= subtasks
-        label = task_gloss(project)
-        for subtask in subtasks:
-          dict_append(node_labels, subtask, label)
-    case "hidden":
-        pass
-    case invalid:
-        raise ValueError(f"Invalid Mode: {invalid}")
-
-  match bucket_mode:
-    case "cluster":
-      for bucket in buckets:
-        contents = bucket_list(bucket)
-        for node in contents:
-          if node not in projects:
-            nodes.add(node)
-        dot_subgraph(bucket, contents)
-    case "label":
-      for bucket in buckets:
-        contents = bucket_list(bucket)
-        for node in contents:
-          if not node in projects:
-            nodes.add(node)
-          dict_append(node_labels, node, bucket)
-    case "node":
-      for bucket in buckets:
-        contents = bucket_list(bucket)
-        print(dot_node(bucket, shape="house"))
-        for c in contents:
-          nodes.add(c)
-          print(dot_edge(bucket, c, "dashed", "grey"))
-    case "hidden":
-      pass
-    case invalid:
-      raise ValueError(f"Invalid mode: {invalid}")
+  for bucket in buckets:
+    contents = bucket_list(bucket)
+    print(dot_node(bucket, shape="house"))
+    for c in contents:
+      nodes.add(c)
+      print(dot_edge(bucket, c, "dashed", "grey"))
 
   nodes |= selected
 
@@ -712,8 +672,6 @@ def dot(*selection):
 
 font          =    os.getenv("GTD_GRAPH_FONT",          "monospace")
 background    =    os.getenv("GTD_GRAPH_BG",            "white")
-bucket_mode   =    os.getenv("GTD_GRAPH_BUCKET_MODE",   "cluster")
-subtasks_mode =    os.getenv("GTD_GRAPH_SUBTASKS_MODE", "cluster")
 rankdir       =    os.getenv("GTD_GRAPH_RANKDIR",       "TB")
 show_contexts = get_env_bool("GTD_GRAPH_SHOW_CONTEXTS", "1")
 show_deps     = get_env_bool("GTD_GRAPH_SHOW_DEPS",     "1")

--- a/gtd.sh
+++ b/gtd.sh
@@ -615,8 +615,6 @@ function graph {
     prefs_export_env \
         "graph/font"          GTD_GRAPH_FONT          "monospace" \
         "graph/bg"            GTD_GRAPH_BG            "white"     \
-        "graph/bucket_mode"   GTD_GRAPH_BUCKET_MODE   "cluster"   \
-        "graph/subtasks_mode" GTD_GRAPH_SUBTASKS_MODE "cluster"   \
         "graph/rankdir"       GTD_GRAPH_RANKDIR       "TB"        \
         "graph/show_contexts" GTD_GRAPH_SHOW_CONTEXTS "1"         \
         "graph/show_deps"     GTD_GRAPH_SHOW_DEPS     "1"         \
@@ -775,27 +773,10 @@ function graph_node_delete {
 # Common keybindings for graph views
 function __graph_bindings {
     prefs_bind_cycle \
-      "alt-b" \
-      "Bucket Mode" \
-      "graph/bucket_mode" \
-      "cluster" \
-      "label" \
-      "node" \
-      "hidden"
-
-    prefs_bind_cycle \
         "alt-r" \
         "Rankdir" \
         "graph/rankdir" \
         "TB" "LR" "RL" "BT"
-
-    prefs_bind_cycle \
-       "alt-s" \
-       "Subtasks Mode" \
-       "graph/subtasks_mode" \
-       "cluster" \
-       "label" \
-       "hidden"
 
     fzf_bind_exec \
         "shift-delete" \
@@ -2658,14 +2639,6 @@ function plan {
         export SUBTASK_ID
     fi
 
-    # save current settings
-    read bm < <(prefs read 'graph/bucket_mode'   'hidden')
-    read sm < <(prefs read 'graph/subtasks_mode' 'hidden')
-
-    # turn off subtasks and buckets
-    prefs write 'graph/bucket_mode' 'cluster'
-    prefs write 'graph/subtasks_mode' 'hidden'
-
     # run mainloop
     fzf_menu \
       "Edit Project Subtasks" \
@@ -2674,10 +2647,6 @@ function plan {
       --preview="$0 __plan_preview {+1}" \
       --with-nth='{2} {3}' \
       -d '|'
-
-    # restore settings
-    prefs write 'graph/bucket_mode' "${bm}"
-    prefs write 'graph/subtasks_mode' "${sm}"
 }
 
 # Interactive Mode ************************************************************
@@ -2990,27 +2959,10 @@ function __interactive_view_submenu {
         "details/graph_nodes" "selected" "query"
 
     prefs_bind_cycle \
-      "B" \
-      "Bucket Mode" \
-      "graph/bucket_mode" \
-      "cluster" \
-      "label" \
-      "node" \
-      "hidden"
-
-    prefs_bind_cycle \
         "r" \
         "Rankdir" \
         "graph/rankdir" \
         "TB" "LR" "RL" "BT"
-
-    prefs_bind_cycle \
-       "S" \
-       "Subtasks Mode" \
-       "graph/subtasks_mode" \
-       "cluster" \
-       "label" \
-       "hidden"
 }
 
 function __interactive_graph_submenu {


### PR DESCRIPTION
For the past couple months, I've been experimenting with different ways of using graphviz's clusters for visualizing both buckets and subproject groups. The end result is that I've given up: the key limitation is that a node must be in exactly one cluster, or else graphviz does some undefined thing. This isn't great for interactive UI, as it masks the true topology of your task graph.

My ultimate solution is to tread buckets as "virtual nodes", and to simply not try to use clusters for subtask groupings at all. If I ever introduce the restriction that a node belong to exactly one bucket at a time, then I could revisit this idea. But there are only certain buckets for which this idea actually makes sense.

In any case, the goal here is to reduce the complexity in the graph rendering logic, and remove some superflous keybindings from the menu system now that I am sure I don't want to switch this behavior on-the-fly.